### PR TITLE
The generates command fails.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "license": "ISC",
   "scripts": {
-    "generates": "npm-run-all -s generate-openapi generate-ruby",
+    "generates": "npm-run-all -s generate-auths generate-api",
     "generate-auths": "/bin/sh ./scripts/root2openapi.sh auths",
     "generate-api": "/bin/sh ./scripts/root2openapi.sh api",
     "watch-auths": "chokidar \"src/services/auths/root.yaml\" \"src/services/auths/**/**/*.yaml\" -c \"npm run-script generate-auths\"",


### PR DESCRIPTION
The generates command fails.
This is because it executes a command that does not exist.